### PR TITLE
Bump infinispan.version from 10.0.1.Final to 10.1.0.Final (#271)

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/pom.xml
+++ b/spring-cloud-zuul-ratelimit-core/pom.xml
@@ -24,7 +24,7 @@
         <bucket4j.version>4.6.0</bucket4j.version>
         <hazelcast.version>3.12.5</hazelcast.version>
         <ignite.version>2.7.6</ignite.version>
-        <infinispan.version>10.0.1.Final</infinispan.version>
+        <infinispan.version>10.1.0.Final</infinispan.version>
     </properties>
 
     <dependencies>

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
@@ -58,13 +58,13 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>10.0.1.Final</version>
+            <version>10.1.0.Final</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons</artifactId>
-            <version>10.0.1.Final</version>
+            <version>10.1.0.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Bumps `infinispan.version` from 10.0.1.Final to 10.1.0.Final.

Updates `infinispan-core` from 10.0.1.Final to 10.1.0.Final
- [Release notes](https://github.com/infinispan/infinispan/releases)
- [Changelog](https://github.com/infinispan/infinispan/blob/master/Jenkinsfile-release)
- [Commits](https://github.com/infinispan/infinispan/compare/10.0.1.Final...10.1.0.Final)

Updates `infinispan-commons` from 10.0.1.Final to 10.1.0.Final
- [Release notes](https://github.com/infinispan/infinispan/releases)
- [Changelog](https://github.com/infinispan/infinispan/blob/master/Jenkinsfile-release)
- [Commits](https://github.com/infinispan/infinispan/compare/10.0.1.Final...10.1.0.Final)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
