### PR TITLE
Bump bucket4j.version from 4.6.0 to 4.7.0 (#276)

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/pom.xml
+++ b/spring-cloud-zuul-ratelimit-core/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <main.basedir>${basedir}/..</main.basedir>
-        <bucket4j.version>4.6.0</bucket4j.version>
+        <bucket4j.version>4.7.0</bucket4j.version>
         <hazelcast.version>3.12.5</hazelcast.version>
         <ignite.version>2.7.6</ignite.version>
         <infinispan.version>10.1.0.Final</infinispan.version>

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-hazelcast/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-hazelcast/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-hazelcast</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-ignite/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-ignite/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-ignite</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-infinispan</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-jcache/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-jcache/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-ignite</artifactId>
-            <version>4.6.0</version>
+            <version>4.7.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps `bucket4j.version` from 4.6.0 to 4.7.0.

Updates `bucket4j-core` from 4.6.0 to 4.7.0
- [Release notes](https://github.com/vladimir-bukhtoyarov/bucket4j/releases)
- [Commits](https://github.com/vladimir-bukhtoyarov/bucket4j/compare/4.6.0...4.7.0)

Updates `bucket4j-jcache` from 4.6.0 to 4.7.0
- [Release notes](https://github.com/vladimir-bukhtoyarov/bucket4j/releases)
- [Commits](https://github.com/vladimir-bukhtoyarov/bucket4j/compare/4.6.0...4.7.0)

Updates `bucket4j-hazelcast` from 4.6.0 to 4.7.0
- [Release notes](https://github.com/vladimir-bukhtoyarov/bucket4j/releases)
- [Commits](https://github.com/vladimir-bukhtoyarov/bucket4j/compare/4.6.0...4.7.0)

Updates `bucket4j-ignite` from 4.6.0 to 4.7.0
- [Release notes](https://github.com/vladimir-bukhtoyarov/bucket4j/releases)
- [Commits](https://github.com/vladimir-bukhtoyarov/bucket4j/compare/4.6.0...4.7.0)

Updates `bucket4j-infinispan` from 4.6.0 to 4.7.0
- [Release notes](https://github.com/vladimir-bukhtoyarov/bucket4j/releases)
- [Commits](https://github.com/vladimir-bukhtoyarov/bucket4j/compare/4.6.0...4.7.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Fixes #

#### Changes proposed in this pull request:
 - 
 -
 -
 
